### PR TITLE
Fix nvm typo containing 'ñ' instead of 'n'

### DIFF
--- a/ubuntu.md
+++ b/ubuntu.md
@@ -36,7 +36,7 @@ sudo apt-get python-pip python-dev python-setuptools pylint python-software-prop
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh | bash
 Add nvm plugin to oh-my-zsh
 nvm ls-remote # pick your favorite version
-ñvm install 0.12.7 # change for your version
+nvm install 0.12.7 # change for your version
 nvm use 0.12.7
 nvm alias default 0.12.7
 ```


### PR DESCRIPTION
Just a little typo on the `nvm` word
